### PR TITLE
header with macros

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,7 @@
+// swift-tools-version:3.1
+
+import PackageDescription
+
+let package = Package(
+    name: "CX11.swift"
+)

--- a/macros.h
+++ b/macros.h
@@ -1,0 +1,4 @@
+
+#ifndef XLIB_ILLEGAL_ACCESS
+#define XLIB_ILLEGAL_ACCESS 1
+#endif

--- a/module.modulemap
+++ b/module.modulemap
@@ -1,10 +1,11 @@
 module CX11 [system] {
-  module Xlib {
-	header "/usr/include/X11/Xlib.h"
-  }
-  module X {
-	header "/usr/include/X11/X.h"
-  }
-  link "X11"
+    header "macros.h"
+    module Xlib {
+        header "/usr/include/X11/Xlib.h"
+    }
+    module X {
+        header "/usr/include/X11/X.h"
+    }
+    link "X11"
 }
 


### PR DESCRIPTION
makes possible to use UnsafeMutablePointer<Display> instead of _XPrivDisplay
